### PR TITLE
Added @NonBinding to Class[] attributes of @Transactional

### DIFF
--- a/src/main/java/javax/transaction/Transactional.java
+++ b/src/main/java/javax/transaction/Transactional.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.interceptor.InterceptorBinding;
+import javax.enterprise.util.Nonbinding;
 
 
   /**
@@ -41,7 +42,9 @@ import javax.interceptor.InterceptorBinding;
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface Transactional {
-      TxType value() default TxType.REQUIRED;
+
+  @Nonbinding
+  TxType value() default TxType.REQUIRED;
  
   public enum TxType {
       REQUIRED,
@@ -52,8 +55,10 @@ public @interface Transactional {
       NEVER
   }
 
+  @Nonbinding
   Class[] rollbackOn() default {};
 
+  @Nonbinding
   Class[] dontRollbackOn() default {};
 
-  }
+}


### PR DESCRIPTION
It is a requirement of CDI to have these methods @Nonbinding. It's also what Oracle do for their version of this interface:

https://java.net/projects/glassfish/sources/svn/content/trunk/api/javaee-api/javax.transaction/src/main/java/javax/transaction/Transactional.java?rev=61794
