### PR TITLE
add Module Name to manifest for automatic module usage in Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </scm>
 
   <properties>
-    <!-- 
+    <!--
         Don't automatically push the tag when using Maven release plugin.
         The release build needs to be staged and verified before the tag is pushed.
     <pushChanges>false</pushChanges>
@@ -61,7 +61,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <resources>          
+              <resources>
                 <resource>
                   <directory>${basedir}</directory>
                   <includes>
@@ -69,9 +69,9 @@
                     <include>README</include>
                   </includes>
                 </resource>
-              </resources>              
+              </resources>
               <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
-            </configuration>            
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -117,6 +117,11 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+            <Automatic-Module-Name>
+              jboss.transaction.api.spec
+            </Automatic-Module-Name>
+      </manifestEntries>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
Java 9 creates a module name from the jar file name. The resolver chokes on the jar name in this case, probably because the _underscore version_ pattern. I've mentioned this on the Jigsaw mailing list already, but it might be a good idea to provide a stable module name anyway.